### PR TITLE
ZKWAS-56

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ The `--output` arg specifies the directory to write all the output files to and 
 ## Generate batch proof from ProofLoadInfos
 
 ```
-cargo run -- --challenge poseidon -k 21 --output ./sample batch --info sample/test.loadinfo.json --name batchsample
+cargo run -- --output ./sample batch --challenge poseidon -k 21 --info sample/test.loadinfo.json --name batchsample
 ```
 
 ## Verify batch proof from ProofLoadInfos
 
 ```
-cargo run -- --challenge poseidon -k 21 --output ./sample verify --info sample/batchsample.loadinfo.json
+cargo run -- --output ./sample verify -k 21 --info sample/batchsample.loadinfo.json
 ```

--- a/README.md
+++ b/README.md
@@ -21,6 +21,18 @@
 
 ```
 
+## General Command Usage
+
+The general usage is as follows:
+
+```
+cargo run -- --output [OUTPUT_DIR] [SUBCOMMAND] --[ARGS]
+```
+
+where `[SUBCOMMAND]` is the command to execute, and `[ARGS]` are the args specific to that command.
+
+The `--output` arg specifies the directory to write all the output files to and is required for all commands.
+
 ## Generate batch proof from ProofLoadInfos
 
 ```

--- a/src/appbuilder.rs
+++ b/src/appbuilder.rs
@@ -34,7 +34,7 @@ pub trait AppBuilder: CommandBuilder {
             .setting(AppSettings::SubcommandRequired)
             .arg(Self::output_path_arg());
 
-        let app = Self::append_params_command(app);
+        let app = Self::append_params_subcommand(app);
         let app = Self::append_setup_subcommand(app);
         let app = Self::append_create_aggregate_proof_subcommand(app);
         let app = Self::append_verify_aggregate_verify_subcommand(app);
@@ -56,8 +56,8 @@ pub trait AppBuilder: CommandBuilder {
         
 
         match top_matches.subcommand() {
-            Some(("params", args)) => {
-                let k: u32 = Self::parse_zkwasm_k_arg(args).unwrap();
+            Some(("params", sub_matches)) => {
+                let k: u32 = Self::parse_zkwasm_k_arg(&sub_matches).unwrap();
                 generate_k_params(k, &output_dir);
             }
             Some(("setup", _)) => {
@@ -67,8 +67,8 @@ pub trait AppBuilder: CommandBuilder {
             }
 
             Some(("batch", sub_matches)) => {
-                let k: u32 = Self::parse_zkwasm_k_arg(&top_matches).unwrap();
-                let hash = Self::parse_hashtype(&top_matches);
+                let k: u32 = Self::parse_zkwasm_k_arg(&sub_matches).unwrap();
+                let hash = Self::parse_hashtype(&sub_matches);
                 let config_files = Self::parse_proof_load_info_arg(sub_matches);
 
                 let mut target_k = None;
@@ -134,8 +134,8 @@ pub trait AppBuilder: CommandBuilder {
             }
 
             Some(("verify", sub_matches)) => {
-                let k: u32 = Self::parse_zkwasm_k_arg(&top_matches).unwrap();
-                let config_files = Self::parse_proof_load_info_arg(sub_matches);
+                let k: u32 = Self::parse_zkwasm_k_arg(&sub_matches).unwrap();
+                let config_files = Self::parse_proof_load_info_arg(&sub_matches);
                 for config_file in config_files.iter() {
                     let proofloadinfo = ProofLoadInfo::load(config_file);
                     let proofs:Vec<ProofInfo<Bn256>> = ProofInfo::load_proof(&output_dir, &proofloadinfo);
@@ -167,7 +167,7 @@ pub trait AppBuilder: CommandBuilder {
             }
 
             Some(("solidity", sub_matches)) => {
-                let k: u32 = Self::parse_zkwasm_k_arg(&top_matches).unwrap();
+                let k: u32 = Self::parse_zkwasm_k_arg(&sub_matches).unwrap();
                 let max_public_inputs_size = 12;
                 let config_file = Self::parse_proof_load_info_arg(sub_matches);
                 let n_proofs = config_file.len() - 1;

--- a/src/appbuilder.rs
+++ b/src/appbuilder.rs
@@ -21,23 +21,20 @@ use log::info;
 */
 
 use super::command::CommandBuilder;
-use crate::exec::exec_setup;
+use crate::exec::generate_k_params;
 
 pub trait AppBuilder: CommandBuilder {
     const NAME: &'static str;
     const VERSION: &'static str;
-    const AGGREGATE_K: u32;
-    const N_PROOFS: usize;
     const MAX_PUBLIC_INPUT_SIZE: usize;
 
     fn app_builder<'a>() -> App<'a> {
         let app = App::new(Self::NAME)
             .version(Self::VERSION)
             .setting(AppSettings::SubcommandRequired)
-            .arg(Self::output_path_arg())
-            .arg(Self::hashtype())
-            .arg(Self::zkwasm_k_arg());
+            .arg(Self::output_path_arg());
 
+        let app = Self::append_params_command(app);
         let app = Self::append_setup_subcommand(app);
         let app = Self::append_create_aggregate_proof_subcommand(app);
         let app = Self::append_verify_aggregate_verify_subcommand(app);
@@ -55,16 +52,23 @@ pub trait AppBuilder: CommandBuilder {
             .expect("output dir is not provided");
 
         fs::create_dir_all(&output_dir).unwrap();
-
-        let k = Self::parse_zkwasm_k_arg(&top_matches).unwrap();
-        let hash = Self::parse_hashtype(&top_matches);
+        println!("output dir: {:?}", output_dir);
+        
 
         match top_matches.subcommand() {
+            Some(("params", args)) => {
+                let k: u32 = Self::parse_zkwasm_k_arg(args).unwrap();
+                generate_k_params(k, &output_dir);
+            }
             Some(("setup", _)) => {
-                exec_setup(Self::AGGREGATE_K, &output_dir);
+                let k: u32 = Self::parse_zkwasm_k_arg(&top_matches).unwrap();
+
+                generate_k_params(k, &output_dir);
             }
 
             Some(("batch", sub_matches)) => {
+                let k: u32 = Self::parse_zkwasm_k_arg(&top_matches).unwrap();
+                let hash = Self::parse_hashtype(&top_matches);
                 let config_files = Self::parse_proof_load_info_arg(sub_matches);
 
                 let mut target_k = None;
@@ -130,6 +134,7 @@ pub trait AppBuilder: CommandBuilder {
             }
 
             Some(("verify", sub_matches)) => {
+                let k: u32 = Self::parse_zkwasm_k_arg(&top_matches).unwrap();
                 let config_files = Self::parse_proof_load_info_arg(sub_matches);
                 for config_file in config_files.iter() {
                     let proofloadinfo = ProofLoadInfo::load(config_file);
@@ -162,6 +167,7 @@ pub trait AppBuilder: CommandBuilder {
             }
 
             Some(("solidity", sub_matches)) => {
+                let k: u32 = Self::parse_zkwasm_k_arg(&top_matches).unwrap();
                 let max_public_inputs_size = 12;
                 let config_file = Self::parse_proof_load_info_arg(sub_matches);
                 let n_proofs = config_file.len() - 1;

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -15,10 +15,7 @@ impl CommandBuilder for CircuitBatcherApp {}
 impl AppBuilder for CircuitBatcherApp {
     const NAME: &'static str = "auto-circuit-batcher";
     const VERSION: &'static str = "v0.1-beta";
-    const AGGREGATE_K: u32 = 21;
     const MAX_PUBLIC_INPUT_SIZE: usize = 64;
-
-    const N_PROOFS: usize = 1;
 }
 
 /// Simple program to greet a person

--- a/src/command.rs
+++ b/src/command.rs
@@ -4,14 +4,23 @@ use clap::Command;
 use super::args::ArgBuilder;
 
 pub trait CommandBuilder: ArgBuilder {
-    fn append_setup_subcommand(app: App) -> App {
-        let command = Command::new("setup");
 
+    fn append_params_command(app: App) -> App {
+        let command = Command::new("params")
+            .arg(Self::zkwasm_k_arg().required(true));
+        app.subcommand(command)
+    }
+
+    fn append_setup_subcommand(app: App) -> App {
+        let command = Command::new("setup")
+        .arg(Self::output_path_arg())
+        .arg(Self::zkwasm_k_arg());
         app.subcommand(command)
     }
 
     fn append_create_aggregate_proof_subcommand(app: App) -> App {
         let command = Command::new("batch")
+            .arg(Self::zkwasm_k_arg())
             .arg(Self::proof_name_arg())
             .arg(Self::proof_load_info_arg());
         app.subcommand(command)
@@ -19,6 +28,7 @@ pub trait CommandBuilder: ArgBuilder {
 
     fn append_verify_aggregate_verify_subcommand(app: App) -> App {
         let command = Command::new("verify")
+            .arg(Self::zkwasm_k_arg())
             .arg(Self::proof_load_info_arg());
 
         app.subcommand(command)
@@ -26,6 +36,7 @@ pub trait CommandBuilder: ArgBuilder {
 
     fn append_generate_solidity_verifier(app: App) -> App {
         let command = Command::new("solidity")
+            .arg(Self::zkwasm_k_arg())
             .arg(Self::sol_dir_arg())
             .arg(Self::proof_load_info_arg());
         app.subcommand(command)

--- a/src/command.rs
+++ b/src/command.rs
@@ -5,7 +5,7 @@ use super::args::ArgBuilder;
 
 pub trait CommandBuilder: ArgBuilder {
 
-    fn append_params_command(app: App) -> App {
+    fn append_params_subcommand(app: App) -> App {
         let command = Command::new("params")
             .arg(Self::zkwasm_k_arg().required(true));
         app.subcommand(command)

--- a/src/command.rs
+++ b/src/command.rs
@@ -21,6 +21,7 @@ pub trait CommandBuilder: ArgBuilder {
     fn append_create_aggregate_proof_subcommand(app: App) -> App {
         let command = Command::new("batch")
             .arg(Self::zkwasm_k_arg())
+            .arg(Self::hashtype())
             .arg(Self::proof_name_arg())
             .arg(Self::proof_load_info_arg());
         app.subcommand(command)

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -43,8 +43,8 @@ use crate::circuits::TestCircuit;
 use crate::circuits::ZkWasmCircuitBuilder;
 */
 
-pub fn exec_setup(aggregate_k: u32, output_dir: &PathBuf) {
-    info!("Setup Params and VerifyingKey");
+pub fn generate_k_params(aggregate_k: u32, output_dir: &PathBuf) {
+    info!("Generating K Params file");
 
     // Setup Aggregate Circuit Params
     {


### PR DESCRIPTION
Split out some of the args for particular commands, and updated README for using CLI.

It currently will have the following structure, 

cli_binary  -o [OUTPUT_DIR] subcommand --args

Output arg will be mandatory for all subcommands, and then followed by subcommand with subcommand specific args.