### PR TITLE
add Params and ProvingKey LRU cache to proof and witness

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bitvec = "1.0.1"
 quote = "1.0.25"
+lru = "0.11.1"
+
 
 [dev-dependencies]
 rusty-fork = "0.3.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,3 +5,4 @@ pub mod command;
 pub mod exec;
 pub mod proof;
 pub mod samples;
+pub mod pk_cache;

--- a/src/pk_cache.rs
+++ b/src/pk_cache.rs
@@ -1,0 +1,40 @@
+use halo2_proofs::arithmetic::Engine;
+use halo2_proofs::poly::commitment::Params;
+use halo2_proofs::plonk::ProvingKey;
+use lru::LruCache;
+use std::num::NonZeroUsize;
+use std::sync::Mutex;
+
+const DEFAULT_CACHE_SIZE: usize = 5;
+
+pub struct PkeyParams<Y: Engine> {
+    pub pkey: ProvingKey<<Y as Engine>::G1Affine>,
+    pub params: Params<<Y as Engine>::G1Affine>,
+}
+
+impl<Y: Engine> PkeyParams<Y> {
+    pub fn new(
+        pkey: ProvingKey<<Y as Engine>::G1Affine>,
+        params: Params<<Y as Engine>::G1Affine>,
+    ) -> Self {
+        PkeyParams {
+            pkey,
+            params,
+        }
+    }
+}
+
+pub struct ProvingKeyCache<Y: Engine> {
+    pub pk_mem_cache: Mutex<LruCache::<String, PkeyParams<Y>>>,
+}
+
+impl <Y: Engine> ProvingKeyCache<Y> {
+    pub fn new() -> Self {
+        let cache = LruCache::<String, PkeyParams<Y>>::new(
+            NonZeroUsize::new(DEFAULT_CACHE_SIZE).unwrap()
+        );
+        ProvingKeyCache {
+            pk_mem_cache: Mutex::new(cache)
+        }
+    }
+}


### PR DESCRIPTION
Added LRU cache to pk_cache.rs.

run tests with:

```
cargo test --package circuits-batcher --lib -- proof::batch_single_circuit --exact --nocapture
cargo test --package circuits-batcher --lib -- proof::cache_hit_single_circuit --exact --nocapture
cargo test --package circuits-batcher --lib -- proof::cache_lru_multi_circuit --exact --nocapture
```