### PR TITLE
Add cache size parameter when creating new cache for pkey/params

### DIFF
--- a/src/proof.rs
+++ b/src/proof.rs
@@ -40,9 +40,9 @@ pub struct ProvingKeyCache<E: MultiMillerLoop> {
 }
 
 impl<E: MultiMillerLoop> ProvingKeyCache<E> {
-    pub fn new() -> Self {
+    pub fn new(cache_size: usize) -> Self {
         let lrucache = LruCache::<String, ProvingKey<E::G1Affine>>::new(
-            NonZeroUsize::new(DEFAULT_CACHE_SIZE).unwrap(),
+            NonZeroUsize::new(cache_size).unwrap(),
         );
         ProvingKeyCache { cache: lrucache }
     }
@@ -61,7 +61,7 @@ impl<E: MultiMillerLoop> ProvingKeyCache<E> {
 
 lazy_static::lazy_static! {
     pub static ref PKEY_CACHE: Mutex<ProvingKeyCache<Bn256>> =
-        Mutex::new(ProvingKeyCache::new());
+        Mutex::new(ProvingKeyCache::new(DEFAULT_CACHE_SIZE));
 }
 
 pub struct ParamsCache<E: MultiMillerLoop> {
@@ -69,9 +69,9 @@ pub struct ParamsCache<E: MultiMillerLoop> {
 }
 
 impl<E: MultiMillerLoop> ParamsCache<E> {
-    pub fn new() -> Self {
+    pub fn new(cache_size: usize) -> Self {
         let lrucache = LruCache::<String, Params<E::G1Affine>>::new(
-            NonZeroUsize::new(DEFAULT_CACHE_SIZE).unwrap(),
+            NonZeroUsize::new(cache_size).unwrap(),
         );
         ParamsCache { cache: lrucache }
     }
@@ -90,7 +90,7 @@ impl<E: MultiMillerLoop> ParamsCache<E> {
 
 lazy_static::lazy_static! {
     pub static ref K_PARAMS_CACHE: Mutex<ParamsCache<Bn256>> =
-        Mutex::new(ParamsCache::new());
+        Mutex::new(ParamsCache::new(DEFAULT_CACHE_SIZE));
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]


### PR DESCRIPTION
to future proof and make more flexible, add cache size param when creating new() so it is not limited to default value/size of 5